### PR TITLE
Fix Service Worker scope and force cache update

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,8 +60,10 @@ $4b203a7918d8f299$exports = $parcel$resolve("service-worker.js");
 
 
 if ('serviceWorker' in navigator) window.addEventListener('load', ()=>{
-    navigator.serviceWorker.register($4b203a7918d8f299$exports).then((registration)=>{
-        console.log('Service Worker registered:', registration);
+    navigator.serviceWorker.register($4b203a7918d8f299$exports, {
+        scope: '/mail_smooth_web/'
+    }).then((registration)=>{
+        console.log('Service Worker registered with scope:', registration.scope);
     }).catch((error)=>{
         console.error('Service Worker registration failed:', error);
     });

--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -100,7 +100,7 @@ var precacheConfig = [
         "e5ef4ed715f96038482dde018e465265"
     ]
 ];
-var cacheName = "sw-precache-v3-dev-" + (self.registration ? self.registration.scope : "");
+var cacheName = "sw-precache-v4-dev-" + (self.registration ? self.registration.scope : "");
 var ignoreUrlParametersMatching = [
     /^utm_/
 ];
@@ -225,7 +225,7 @@ self.addEventListener("fetch", (event)=>{
     // 既存のキャッシュ処理
     if (event.request.method === "GET") {
         var urlWithoutIgnoredParams = stripIgnoredUrlParameters(event.request.url, ignoreUrlParametersMatching);
-        var cacheName = "sw-precache-v3-dev-" + (self.registration ? self.registration.scope : "");
+        var cacheName = "sw-precache-v4-dev-" + (self.registration ? self.registration.scope : "");
         var cacheKey = urlsToCacheKeys.get(urlWithoutIgnoredParams);
         if (cacheKey) event.respondWith(caches.open(cacheName).then(function(cache) {
             return cache.match(cacheKey).then(function(response) {

--- a/src/index.html
+++ b/src/index.html
@@ -21,9 +21,11 @@
         // Service Workerの登録
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register(new URL('./service-worker.js', import.meta.url))
+                navigator.serviceWorker.register(new URL('./service-worker.js', import.meta.url), {
+                    scope: '/mail_smooth_web/'
+                })
                     .then(registration => {
-                        console.log('Service Worker registered:', registration);
+                        console.log('Service Worker registered with scope:', registration.scope);
                     })
                     .catch(error => {
                         console.error('Service Worker registration failed:', error);

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -75,7 +75,7 @@ var precacheConfig = [
     ],
 ];
 var cacheName =
-    "sw-precache-v3-dev-" + (self.registration ? self.registration.scope : "");
+    "sw-precache-v4-dev-" + (self.registration ? self.registration.scope : "");
 
 var ignoreUrlParametersMatching = [/^utm_/];
 
@@ -291,7 +291,7 @@ self.addEventListener("fetch", (event) => {
             event.request.url,
             ignoreUrlParametersMatching
         );
-        var cacheName = "sw-precache-v3-dev-" + (self.registration ? self.registration.scope : "");
+        var cacheName = "sw-precache-v4-dev-" + (self.registration ? self.registration.scope : "");
         var cacheKey = urlsToCacheKeys.get(urlWithoutIgnoredParams);
         
         if (cacheKey) {


### PR DESCRIPTION
Changes:
- Add explicit scope '/mail_smooth_web/' to Service Worker registration
- Update Service Worker cache version from v3 to v4 to force update
- This ensures the Service Worker can intercept share-target POST requests

The 405 error occurs because GitHub Pages rejects POST requests. The Service Worker must intercept these requests before they reach the server. Explicit scope ensures proper interception.